### PR TITLE
Run rubocop only in PR

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,9 +1,6 @@
 name: "rubocop"
 
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
     branches:
       - "main"


### PR DESCRIPTION
rubocop can run only in PR, so stop to run rubocop when merged to `main`.