### PR TITLE
disable quoted-strings

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -34,7 +34,6 @@ rules:
     level: warning
   new-lines: enable
   octal-values: disable
-  quoted-strings:
-    quote-type: double
+  quoted-strings: disable
   trailing-spaces: disable
   truthy: disable


### PR DESCRIPTION
`disable quoted-strings` leads workflow file too complicated, so rule is disabled.